### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Add the following snippet to your `.zshrc` file:
 antibody bundle carloscuesta/materialshell
 ```
 
+### [Fig](https://fig.io)
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+
+Install `materialshell` in just one click.
+
+<a href="https://fig.io/plugins/other/materialshell_carloscuesta" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### [zgen](https://github.com/tarjoilija/zgen)
 
 Add the following snippet to your `.zshrc` file:


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`materialshell` is already listed in the store so we'd love to have it listed as a download method on your README.

Thanks so much and please let me know if you have any questions!