### PR TITLE
Fix not loading for zplug

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zgen load carloscuesta/materialshell materialshell
 Add the following snippet to your `.zshrc` file:
 
 ```sh
-zplug carloscuesta/materialshell, use:materialshell, from:github, as:theme
+zplug carloscuesta/materialshell, use:materialshell.zsh-theme, from:github, as:theme
 ```
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zgen load carloscuesta/materialshell materialshell
 Add the following snippet to your `.zshrc` file:
 
 ```sh
-zplug carloscuesta/materialshell, from:github, as:theme
+zplug carloscuesta/materialshell, use:materialshell.zsh, from:github, as:theme
 ```
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zgen load carloscuesta/materialshell materialshell
 Add the following snippet to your `.zshrc` file:
 
 ```sh
-zplug carloscuesta/materialshell, use:materialshell.zsh-theme, from:github, as:theme
+zplug carloscuesta/materialshell, from:github, as:theme
 ```
 
 ### Manual


### PR DESCRIPTION
The plugin silently does not load otherwise

without `use` it will [load `*.zsh`](https://github.com/zplug/zplug/wiki/Configurations#use-tag)